### PR TITLE
Updated WhatsApp link

### DIFF
--- a/src/data/stubs.php
+++ b/src/data/stubs.php
@@ -20,6 +20,6 @@ $stubs = [
     'tumblr' => 'http://www.tumblr.com/share?v=3&u={url}&t={text}',
     'twitter' => 'https://twitter.com/intent/tweet?text={text}&url={url}',
     'vk' => 'https://vk.com/share.php?title={text}&url={url}',
-    'whatsapp' => 'whatsapp://send?text={text}%20{url}',
+    'whatsapp' => 'https://api.whatsapp.com/send?text={text}%20{url}',
     'xing' => 'https://www.xing.com/app/user?op=share;url={url};title={text}',
 ];

--- a/tests/SocialShareUrlTest.php
+++ b/tests/SocialShareUrlTest.php
@@ -25,7 +25,7 @@ class SocialShareUrlTest extends TestCase
         'tumblr' => 'http://www.tumblr.com/share?v=3&u=http%3A%2F%2Fexample.com&t=Foo+bar',
         'twitter' => 'https://twitter.com/intent/tweet?text=Foo+bar&url=http%3A%2F%2Fexample.com',
         'vk' => 'https://vk.com/share.php?title=Foo+bar&url=http%3A%2F%2Fexample.com',
-        'whatsapp' => 'whatsapp://send?text=Foo+bar%20http%3A%2F%2Fexample.com',
+        'whatsapp' => 'https://api.whatsapp.com/send?text=Foo+bar%20http%3A%2F%2Fexample.com',
         'xing' => 'https://www.xing.com/app/user?op=share;url=http%3A%2F%2Fexample.com;title=Foo+bar',
     ];
 


### PR DESCRIPTION
This is an update for WhatsApp social button. Old link would not provide context for desktop browsers or devices without WhatsApp installed. This new link will redirect to WhatsApp's site providing some context as to what the button will do. 